### PR TITLE
Examples + refactor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@
 [![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)](http://gruntjs.com/)
 
 _Work in progress!_
+
+## Examples
+
+1. Clone this repo
+1. Install project dependencies with `npm install`
+1. Start the development web server with `npm start`
+1. Browse to <http://localhost:8080/>

--- a/eslint/eslint-jsx.yaml
+++ b/eslint/eslint-jsx.yaml
@@ -1,0 +1,53 @@
+---
+plugins:
+  - react
+
+ecmaFeatures:
+  jsx: true
+
+rules:
+  react/display-name: 0
+  react/jsx-boolean-value:
+    - 2
+    - always
+  react/jsx-closing-bracket-location: 0
+  react/jsx-curly-spacing:
+    - 2
+    - never
+  react/jsx-indent-props:
+    - 2
+    - 2
+  react/jsx-max-props-per-line:
+    - 1
+    -
+      maximum: 3
+  react/jsx-no-duplicate-props:
+    - 2
+    - ignoreCase: false
+  react/jsx-no-literals: 0
+  react/jsx-no-undef: 2
+  jsx-quotes:
+    - 2
+    - prefer-double
+  react/jsx-sort-prop-types: 0
+  react/jsx-sort-props: 0
+  react/jsx-uses-react: 2
+  react/jsx-uses-vars: 2
+  react/no-danger: 2
+  react/no-did-mount-set-state:
+    - 2
+    - allow-in-func
+  react/no-did-update-set-state: 2
+  react/no-multi-comp: 0
+  react/no-set-state: 0
+  react/no-unknown-property: 2
+  react/prop-types: 1
+  react/react-in-jsx-scope: 2
+  react/require-extension:
+    - 2
+    - extensions:
+      - ".js"
+      - ".jsx"
+  react/self-closing-comp: 2
+  react/sort-comp: 2
+  react/wrap-multilines: 2

--- a/examples/.eslintrc.yaml
+++ b/examples/.eslintrc.yaml
@@ -1,0 +1,7 @@
+---
+env:
+  browser: true
+extends:
+  - "../eslint/eslint-defaults.yaml"
+  - "../eslint/eslint-es2015.yaml"
+  - "../eslint/eslint-jsx.yaml"

--- a/examples/bocoup/app.jsx
+++ b/examples/bocoup/app.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import {render} from 'react-dom';
+import {Router, Route, IndexRoute, Link, browserHistory} from 'react-router';
+
+import auth from './auth';
+
+const Login = ({location: {state}}) => {
+  const redirectTo = state && state.nextPathname;
+  return (
+    <div>
+      <p>You must log in to use this app!</p>
+      <a href={auth.authUrl(redirectTo)}>Log In</a>
+    </div>
+  );
+};
+
+const App = ({children}) => (
+  <div>
+    <h1>Bocoup API Auth Example</h1>
+    <AuthStatus />
+    <h2>Content</h2>
+    {children}
+  </div>
+);
+
+const AuthStatus = () => (
+  <span>
+    You are currently logged in. <Link to="/" onClick={auth.logout}>Log out</Link>
+  </span>
+);
+
+const Index = () => (
+  <div>
+    <p>This is the index page.</p>
+    <p>You should be able to log out from this page, and then log back in.</p>
+    <p><Link to="/subpage?foo=1&bar=2">Visit the subpage to test deep-link
+      redirection and handling API errors.</Link></p>
+  </div>
+);
+
+function simulateApiError(event) {
+  event.preventDefault();
+  // This would normally be done in the error callback of an API Ajax request:
+  auth.logout({redirectBack: true});
+  // const {token} = auth.getCredentials();
+  // request
+  //   .get('/some-request')
+  //   .set('Authorization', `Bearer ${token}`)
+  //   .then(({body}) => {
+  //     console.log(body);
+  //   }, err => {
+  //     if (err.status === 401) {
+  //       auth.logout({redirectBack: true});
+  //     }
+  //     throw err;
+  //   });
+}
+
+const SubPage = () => (
+  <div>
+    <p>This is the subpage.</p>
+    <h3>Deep-link Redirection</h3>
+    <ol>
+      <li>Note the URL to this page, and copy it to the clipboard.</li>
+      <li>Click the "Log out" link.</li>
+      <li>Paste the URL you copied into the address bar. You should be redirected to the login page.</li>
+      <li>Click the "Log in" link.</li>
+      <li>You should be redirected to GitHub*, then back to the original page, with the query string intact.</li>
+    </ol>
+    <h3>Handling API 401 Errors</h3>
+    <ol>
+      <li>Note the URL to this page.</li>
+      <li>Click <Link to="/" onClick={simulateApiError}>Simulate an API error</Link>.</li>
+      <li>You should be redirected to the login page.</li>
+      <li>Click the "Log in" link.</li>
+      <li>You should be redirected to GitHub*, then back to the original page, with the query string intact.</li>
+    </ol>
+    <p><i>* Unless the Bocoup API remembers you from a previous login.</i></p>
+    <p><Link to="/">Return to the index.</Link></p>
+  </div>
+);
+
+const routes = (
+  <Router history={browserHistory}>
+    <Route path="/login" component={Login} onEnter={auth.requireNoAuth} />
+    <Route path="/" component={App} onEnter={auth.requireAuth}>
+      <IndexRoute component={Index} />
+      <Route path="subpage" component={SubPage} />
+    </Route>
+  </Router>
+);
+
+render(routes, document.getElementById('root'));

--- a/examples/bocoup/auth.js
+++ b/examples/bocoup/auth.js
@@ -1,0 +1,44 @@
+import queryString from 'query-string';
+import {browserHistory} from 'react-router';
+import Auth from 'react-router-oauth';
+
+// A few app defaults.
+const loginRoute = '/login';
+const loggedInRoute = '/';
+
+// Not actually used by the auth system, but it's related.
+function authUrl(redirectTo) {
+  const API_AUTH_URL = 'https://api.bocoup.com/v3/auth/authenticate';
+  const provider = 'github';
+  const referer = this.getBaseUrl(redirectTo);
+  const search = queryString.stringify({provider, referer});
+  return `${API_AUTH_URL}?${search}`;
+}
+
+// If auth is required for the current route, but the user is not already
+// authed, this function will be called. If it returns an object, that object
+// will be used to log the user in.
+function parseCredentials() {
+  // Get auth params from the query string.
+  const params = queryString.parse(location.search);
+  const {access_token: token, id} = params;
+  if (token && id) {
+    // Remove related params from the query object.
+    delete params.access_token;
+    delete params.id;
+    // Replace the current page with the same page, minus the auth query params.
+    let search = queryString.stringify(params);
+    if (search) { search = `?${search}`; }
+    history.replaceState('', {}, `${location.pathname}${search}`);
+    // The returned object will be used to login.
+    return {token, id};
+  }
+}
+
+export default new Auth({
+  browserHistory,
+  loginRoute,
+  loggedInRoute,
+  authUrl,
+  parseCredentials,
+});

--- a/examples/bocoup/index.html
+++ b/examples/bocoup/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Bocoup API Auth Example</title>
+  <base href="/bocoup"/>
+</head>
+<body>
+  <a href="/">&laquo; Return to Examples Index</a>
+  <div id="root"></div>
+  <script src="/__build__/shared.js"></script>
+  <script src="/__build__/bocoup.js"></script>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Examples</title>
+</head>
+<body>
+  <h1>Examples</h1>
+  <ul>
+    <li><a href="bocoup">Bocoup API Auth Example</a></li>
+  </ul>
+</body>
+</html>

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,0 +1,32 @@
+// Based on the examples in https://github.com/rackt/react-router
+
+import fs from 'fs';
+import path from 'path';
+import express from 'express';
+import rewrite from 'express-urlrewrite';
+import webpack from 'webpack';
+import webpackDevMiddleware from 'webpack-dev-middleware';
+import webpackConfig from './webpack.config.babel';
+
+const app = express();
+const compiler = webpack(webpackConfig);
+
+app.use(webpackDevMiddleware(compiler, {
+  publicPath: '/__build__/',
+  stats: {
+    colors: true,
+  },
+}));
+
+fs.readdirSync(__dirname).forEach(file => {
+  const stat = fs.statSync(path.join(__dirname, file));
+  if (stat.isDirectory()) {
+    app.use(rewrite(`/${file}/*`, `/${file}/index.html`));
+  }
+});
+
+app.use(express.static(__dirname));
+
+app.listen(8080, function() {
+  console.log('Server listening on http://localhost:8080, Ctrl+C to stop.');
+});

--- a/examples/webpack.config.babel.js
+++ b/examples/webpack.config.babel.js
@@ -1,0 +1,57 @@
+// Based on the examples in https://github.com/rackt/react-router
+
+import fs from 'fs';
+import path from 'path';
+import webpack from 'webpack';
+
+const getPath = (...args) => path.join(__dirname, ...args);
+
+export default {
+  devtool: 'cheap-module-eval-source-map',
+
+  resolve: {
+    extensions: ['', '.js', '.jsx'],
+    alias: {
+      'react-router-oauth': getPath('../build'),
+    },
+  },
+
+  entry: fs.readdirSync(getPath()).reduce((entries, dir) => {
+    const stat = fs.statSync(getPath(dir));
+    if (stat.isDirectory()) {
+      entries[dir] = getPath(dir, 'app');
+    }
+    return entries;
+  }, {}),
+
+  output: {
+    path: getPath('__build__'),
+    filename: '[name].js',
+    chunkFilename: '[id].chunk.js',
+    publicPath: '/__build__/',
+  },
+
+  module: {
+    preLoaders: [
+      {
+        test: /\.jsx?$/,
+        loader: 'eslint-loader',
+        include: getPath(),
+      },
+    ],
+    loaders: [
+      {
+        test: /\.jsx?$/,
+        loader: 'babel',
+        include: getPath(),
+        query: {
+          presets: ['react', 'es2015'],
+        },
+      },
+    ],
+  },
+
+  plugins: [
+    new webpack.optimize.CommonsChunkPlugin('shared.js'),
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-router-oauth",
   "description": "Basic oauth support for react-router",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "dependencies": {
     "babel-plugin-transform-runtime": "^6.4.0",
     "babel-preset-es2015": "^6.3.13",
@@ -14,11 +14,22 @@
   "scripts": {
     "prepublish": "grunt test build",
     "build": "grunt build",
+    "start": "babel-node examples/server",
     "test": "grunt test"
   },
   "devDependencies": {
+    "babel": "^6.5.1",
+    "babel-cli": "^6.5.1",
+    "babel-core": "^6.5.1",
+    "babel-loader": "^6.2.2",
+    "babel-preset-es2015": "^6.5.0",
+    "babel-preset-react": "^6.5.0",
     "babel-register": "^6.4.3",
     "chai": "^3.4.1",
+    "eslint-loader": "^1.2.1",
+    "eslint-plugin-react": "^3.16.1",
+    "express": "^4.13.4",
+    "express-urlrewrite": "^1.2.0",
     "grunt": "^0.4.5",
     "grunt-babel": "^6.0.0",
     "grunt-cli": "^0.1.13",
@@ -26,6 +37,12 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-eslint": "^17.3.1",
     "grunt-mocha-test": "^0.12.7",
-    "mocha": "^2.3.4"
+    "mocha": "^2.3.4",
+    "react": "^0.14.7",
+    "react-dom": "^0.14.7",
+    "react-router": "^2.0.0",
+    "rewrite": "0.0.1",
+    "webpack": "^1.12.13",
+    "webpack-dev-middleware": "^1.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build"
   ],
   "scripts": {
-    "prepublish": "grunt build",
+    "prepublish": "grunt test build",
     "build": "grunt build",
     "test": "grunt test"
   },

--- a/src/auth.js
+++ b/src/auth.js
@@ -85,22 +85,18 @@ export default class Auth {
 
   // React-router onEnter handler. If the given route (or any child route) is
   // not authed, redirect to the specified `loginRoute`
-  requireAuth() {
-    return (nextState, replace) => {
+  requireAuth(nextState, replace) {
       if (!this.isLoggedIn()) {
         const nextPathname = this.getRoutePath(nextState.location);
         this.redirectToLogin({replace, nextPathname});
       }
-    };
   }
 
   // React-router onEnter handler. If the given route (or any child route) is
   // authed, redirect to the specified `loggedInRoute`
-  requireNoAuth() {
-    return (nextState, replace) => {
+  requireNoAuth(nextState, replace) {
       if (this.isLoggedIn()) {
         replace(this.loggedInRoute);
       }
-    };
   }
 }

--- a/tools/gruntfile.js
+++ b/tools/gruntfile.js
@@ -26,6 +26,10 @@ const eslint = {
     options: {configFile: 'src/.eslintrc-test.yaml'},
     src: 'src/**/*.test.js',
   },
+  examples: {
+    options: {configFile: 'examples/.eslintrc.yaml'},
+    src: 'examples/**/*.{js,jsx}',
+  },
   tools: {
     options: {configFile: 'tools/.eslintrc.yaml'},
     src: 'tools/**/*.js',

--- a/tools/gruntfile.js
+++ b/tools/gruntfile.js
@@ -54,7 +54,7 @@ const mochaTest = {
 const watch = {
   src: {
     files: ['<%= eslint.src.src %>'],
-    tasks: ['eslint:src', 'mochaTest'],
+    tasks: ['eslint:src', 'mochaTest', 'build'],
   },
   test: {
     files: ['<%= eslint.test.src %>'],
@@ -85,7 +85,7 @@ grunt.initConfig({
   watch,
 });
 
-grunt.registerTask('build', ['test', 'clean', 'babel']);
+grunt.registerTask('build', ['clean', 'babel']);
 grunt.registerTask('test', ['eslint', 'mochaTest']);
 grunt.registerTask('default', ['watch']);
 


### PR DESCRIPTION
- Add examples infrastructure and Bocoup API auth example. Connects to #1.
- Convert requireAuth, requireNoAuth to non-factory functions. Closes #7.
- Other misc things.

This contains an API change so it will need to be published to npm as 0.2.0.

TODO: GitHub auth example, which is more complex than I thought it would be.
